### PR TITLE
Fix leaflet map not rendering issue

### DIFF
--- a/15-Mapty/starter/script.js
+++ b/15-Mapty/starter/script.js
@@ -21,10 +21,19 @@ class App {
     inputType.addEventListener('change', this._toggleElevationField);
   }
 
+  _geoLocationErrorHandler() {
+    const pandaneCordinates = {
+      coords: { latitude: '20.3633277', longitude: '73.851463' },
+    };
+    this._loadMap(pandaneCordinates);
+  }
+
   _getPosition() {
     if (navigator.geolocation);
-    navigator.geolocation.getCurrentPosition(this._loadMap.bind(this), () =>
-      alert('Could not get your position!')
+    navigator.geolocation.getCurrentPosition(
+      this._loadMap.bind(this),
+      this._geoLocationErrorHandler.bind(this),
+      { timeout: 2000 },
     );
   }
 
@@ -74,7 +83,7 @@ class App {
           autoClose: false,
           closeOnClick: false,
           className: 'running-popup',
-        })
+        }),
       )
       .setPopupContent('Workout!')
       .openPopup();


### PR DESCRIPTION
Fix: Leaflet map now renders correctly by falling back to hardcoded coordinates when geolocation fails.